### PR TITLE
add color picker storage

### DIFF
--- a/widget/color-item.html
+++ b/widget/color-item.html
@@ -1,0 +1,62 @@
+<dom-module id="color-item">
+    <style>
+        :host {
+            width: 23px;
+            height: 23px;
+            margin: 0 4px 4px 0;
+            float: left;
+            background: white;
+            border: 1px solid #555;
+            cursor: pointer;
+        }
+    </style>
+
+    <template></template>
+
+    <script type="text/javascript">
+        'use strict'
+
+        Editor.registerElement({
+            listeners: {
+                'click': '_onClick',
+                'dblclick': '_onDbClick'
+            },
+
+            properties: {
+                color: {
+                    type: String,
+                    value: '',
+                    observer: '_onColorChanged'
+                }
+            },
+
+            created () {
+            },
+
+            ready () {
+            },
+
+            _onColorChanged ( color ) {
+                var style = this.style;
+                style['background'] = color;
+            },
+
+            _onClick ( event ) {
+                event.stopPropagation();
+                event.preventDefault();
+                clearTimeout(this._cilckTimer);
+                this._cilckTimer = setTimeout(function () {
+                    this.fire('select-color', this.color);
+                }.bind(this), 300);
+            },
+
+            _onDbClick ( event ) {
+                event.stopPropagation();
+                event.preventDefault();
+                clearTimeout(this._cilckTimer);
+                this.fire('change-color', this.index);
+            }
+
+        });
+    </script>
+</dom-module>

--- a/widget/color-picker.css
+++ b/widget/color-picker.css
@@ -115,6 +115,18 @@
     right: -6px
 }
 
+.storageGroup {
+    height: 0;
+    position: relative;
+}
+
+.storageGroup color-storage {
+    position: absolute;
+    z-index: 1;
+    top: -66px;
+    left: 10px;
+}
+
 .inputGroup {
     display: flex;
     margin: 10px;

--- a/widget/color-picker.html
+++ b/widget/color-picker.html
@@ -1,4 +1,5 @@
 <link rel="import" href="packages://ui-kit/widget/unit-input/unit-input.html">
+<link rel="import" href="color-storage.html">
 
 <dom-module id="color-picker">
     <link rel="import" type="css" href="color-picker.css">
@@ -23,11 +24,22 @@
             </div>
         </div>
 
+        <div class="storageGroup">
+            <color-storage
+                    id="storage"
+                    storage="[[storage]]"
+                    on-mouseover="_onCssMouseOver"
+                    on-mouseout="_onCssMouseOut"
+                    hidden></color-storage>
+        </div>
+
         <div class="inputGroup">
             <div class="input">
                 <editor-input
                     value="[[css]]"
                     on-value-changed="_onCssInputChanged"
+                    on-mouseover="_onCssMouseOver"
+                    on-mouseout="_onCssMouseOut"
                 ></editor-input>
             </div>
             <div class="input">

--- a/widget/color-picker.js
+++ b/widget/color-picker.js
@@ -4,6 +4,11 @@
     const Chroma = require('chroma-js');
 
     Editor.registerElement({
+        listeners: {
+            'select-color': '_onSelectItemColor',
+            'change-color': '_onChangeItemColor'
+        },
+
         properties: {
             noAlpha: {
                 type: Boolean,
@@ -29,6 +34,11 @@
                 type: String,
                 value: '#FFFFFF'
             },
+
+            storage: {
+                type: String,
+                value: 'storage'
+            }
         },
 
         created: function () {
@@ -270,6 +280,35 @@
                 event.target.value = color.css;
                 this.set('css', color.css);
             }
+        },
+
+        _onSelectItemColor (event, color) {
+            event.stopPropagation();
+            event.preventDefault();
+            this.set('css', color);
+        },
+
+        _onChangeItemColor (event, index) {
+            event.stopPropagation();
+            event.preventDefault();
+            this.$.storage.changeItemColor(index, this.css);
+        },
+
+        _onCssMouseOver (event) {
+            event.stopPropagation();
+            event.preventDefault();
+            clearTimeout(this._hiddenStorageTimer);
+            this.$.storage.set('hidden', false);
+            this.$.storage.update();
+        },
+
+        _onCssMouseOut (event) {
+            event.stopPropagation();
+            event.preventDefault();
+            clearTimeout(this._hiddenStorageTimer);
+            this._hiddenStorageTimer = setTimeout(() => {
+                this.$.storage.set('hidden', true);
+            }, 400);
         }
     });
 })();

--- a/widget/color-storage.css
+++ b/widget/color-storage.css
@@ -1,0 +1,17 @@
+.content {
+    height: 60px;
+    width: 145px;
+    background: #333;
+    padding: 4px 0 0 4px;
+    border: 1px solid #555;
+}
+
+.arrow {
+    width: 8px;
+    height: 8px;
+    background: #333;
+    margin-left: 10px;
+    transform: rotate(45deg) translate(0, -5px);
+    border-right: 1px solid #555;
+    border-bottom: 1px solid #555;
+}

--- a/widget/color-storage.html
+++ b/widget/color-storage.html
@@ -1,0 +1,22 @@
+<link rel="import" href="color-item.html">
+
+<dom-module id="color-storage">
+    <link rel="import" type="css" href="color-storage.css">
+
+    <template>
+
+        <div class="content">
+            <template is="dom-repeat" items="[[colors]]">
+                <color-item
+                        index="[[index]]"
+                        color="[[item]]"
+                        title="双击将当前颜色保存到这里"
+                ></color-item>
+            </template>
+        </div>
+        <div class="arrow"></div>
+
+    </template>
+
+    <script type="text/javascript" src="color-storage.js"></script>
+</dom-module>

--- a/widget/color-storage.js
+++ b/widget/color-storage.js
@@ -1,0 +1,39 @@
+'use strict';
+
+Editor.registerElement({
+    properties: {
+        colors: {
+            type: Array,
+            value: []
+        },
+
+        storage: {
+            type: String,
+            value: 'storage'
+        }
+    },
+
+    ready () {
+        this.update();
+    },
+
+    update () {
+        var colorString = localStorage[`color_picker_${this.storage}`] || '';
+        var colors = colorString.split(',');
+        for (let i=0; i<10; i++) {
+            let color = colors[i];
+            if (color) continue;
+            colors[i] = '';
+        }
+        this.set('colors', colors);
+    },
+
+    changeItemColor (index, color) {
+        var colors = this.colors.map((c, i) => {
+            return index === i ? color : c;
+        });
+        this.set('colors', colors);
+        localStorage[`color_picker_${this.storage}`] = colors.join(',');
+    }
+
+});


### PR DESCRIPTION
增加颜色保存功能：

![image](https://cloud.githubusercontent.com/assets/7113508/13517542/4ec1df06-e1ff-11e5-9c95-05971e770cc1.png)

鼠标移入十六进制颜色输入框，就会在上面弹出两排颜色选择框。默认黑色。

操作方式：
鼠标单击颜色框 - 应用当前点击的颜色
鼠标双击颜色框 - 将当前的颜色值保存到这个框内

颜色值存在localStorage里面。
在color-picker上增加了一个storage字段，这个字段是一个字符串，标明当前存储的索引。。。默认是‘storage’

https://github.com/cocos-creator/fireball/issues/1826
